### PR TITLE
Adding Gitpod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 !/.editorconfig
 !.gitkeep
 
+# Drupal website for testing
+!.gitpod/
+!.gitpod.yml
+!.gitpod/.gitpod.Dockerfile
+/drupal-website/
+
 # Other ignored paths and files.
 /vendor
 /composer.lock

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,68 @@
+image:
+  file: .gitpod/.gitpod.Dockerfile
+
+# ddev and composer are running as part of the prebuild
+# when starting a workspace all docker images are ready
+tasks:
+  - init: |
+      .gitpod/download-ddev-images.sh
+      .gitpod/ddev-in-gitpod-setup.sh
+      .gitpod/install-default-website.sh
+    command: |
+      .gitpod/ddev-in-gitpod-setup.sh
+      .gitpod/env-setup.sh
+
+# VScode xdebug extension
+vscode:
+  extensions:
+    - felixfbecker.php-debug
+
+ports:
+  # Used by projector
+  - port: 6942
+    onOpen: ignore
+  # Direct-connect ddev-webserver port that is the main port
+  - port: 8080
+    onOpen: ignore
+  # Currently un-notified and unsupported mailhog http port
+  - port: 8025
+    onOpen: ignore
+  # Currently un-notified and unsupported mailhog https port
+  - port: 8026
+    onOpen: ignore
+  # Currently un-notified and unsupported phpmyadmin http port
+  - port: 8036
+    onOpen: ignore
+  # Currently un-notified and unsupported phpmyadmin https port
+  - port: 8037
+    onOpen: ignore
+  # router http port that we're ignoring.
+  - port: 8888
+    onOpen: ignore
+  # router https port that we're ignoring.
+  - port: 8889
+    onOpen: ignore
+  # xdebug port
+  - port: 9000
+    onOpen: ignore
+  # projector port
+  - port: 9999
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true

--- a/.gitpod/.gitpod.Dockerfile
+++ b/.gitpod/.gitpod.Dockerfile
@@ -1,0 +1,30 @@
+FROM gitpod/workspace-full
+SHELL ["/bin/bash", "-c"]
+
+RUN sudo apt-get -qq update
+# Install required libraries for Projector + PhpStorm
+RUN sudo apt-get -qq install -y patchutils python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6 telnet netcat
+# Install Projector
+RUN pip3 install projector-installer
+# Install PhpStorm
+RUN mkdir -p ~/.projector/configs  # Prevents projector install from asking for the license acceptance
+RUN projector install 'PhpStorm 2020.3.2' --no-auto-run
+
+# Install ddev
+RUN brew update && brew install drud/ddev/ddev
+
+# Install GitUI (terminal-ui for git)
+RUN brew install gitui
+
+# Install dialog (interactive script)
+RUN brew install dialog
+
+# Install latest composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN sudo php composer-setup.php --install-dir /usr/bin --filename composer
+RUN php -r "unlink('composer-setup.php');"
+
+###
+### Initiate a rebuild of Gitpod's image by updating this comment #4
+###

--- a/.gitpod/ddev-in-gitpod-setup.sh
+++ b/.gitpod/ddev-in-gitpod-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+if [ -n "$DEBUG_DRUPALPOD" ]; then
+    set -x
+fi
+
+# Set up ddev for use on gitpod
+DRUPAL_DIR="${GITPOD_REPO_ROOT}"/drupal-website
+mkdir -p "$DRUPAL_DIR"
+DDEV_DIR="$DRUPAL_DIR"/.ddev
+mkdir -p "$DDEV_DIR"
+
+# Generate a config.gitpod.yaml that adds the gitpod
+# proxied ports so they're known to ddev.
+shortgpurl="${GITPOD_WORKSPACE_URL#'https://'}"
+
+cat <<CONFIGEND > "${DDEV_DIR}"/config.gitpod.yaml
+#ddev-gitpod-generated
+php_version: "8.0"
+use_dns_when_possible: false
+# Throwaway ports, otherwise Gitpod throw an error 'port needs to be > 1024'
+router_http_port: "8888"
+router_https_port: "8889"
+additional_fqdns:
+- 8888-${shortgpurl}
+- 8025-${shortgpurl}
+- 8036-${shortgpurl}
+CONFIGEND
+
+# We need host.docker.internal inside the container,
+# So add it via docker-compose.host-docker-internal.yaml
+hostip=$(awk "\$2 == \"$HOSTNAME\" { print \$1; }" /etc/hosts)
+
+cat <<COMPOSEEND >"${DDEV_DIR}"/docker-compose.host-docker-internal.yaml
+#ddev-gitpod-generated
+version: "3.6"
+services:
+  web:
+    environment:
+      - DRUSH_OPTIONS_URI=$(gp url 8080)
+    extra_hosts:
+    - "host.docker.internal:${hostip}"
+    # This adds 8080 on the host (bound on all interfaces)
+    # It goes directly to the web container without
+    # ddev-nginx
+    ports:
+    - 8080:80
+COMPOSEEND
+
+# Misc housekeeping before start
+ddev config global --instrumentation-opt-in=true --router-bind-all-interfaces=true

--- a/.gitpod/download-ddev-images.sh
+++ b/.gitpod/download-ddev-images.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+if [ -n "$DEBUG_DRUPALPOD" ]; then
+    set -x
+fi
+
+ddev version | awk '/(drud|phpmyadmin)/ {print $2;}' >/tmp/images.txt
+while IFS= read -r item
+do
+  docker pull "$item"
+done < <(cat /tmp/images.txt)

--- a/.gitpod/env-setup.sh
+++ b/.gitpod/env-setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+if [ -n "$DEBUG_DRUPALPOD" ]; then
+    set -x
+fi
+
+# Create a phpstorm command
+sudo cp "${GITPOD_REPO_ROOT}"/.gitpod/phpstorm.template.sh /usr/local/bin/phpstorm
+
+# Start ddev in the drupal website directory
+DRUPAL_DIR="${GITPOD_REPO_ROOT}"/drupal-website
+cd "$DRUPAL_DIR" && ddev start
+
+#Open preview browser
+gp preview "$(gp url 8080)"

--- a/.gitpod/install-default-website.sh
+++ b/.gitpod/install-default-website.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+if [ -n "$DEBUG_DRUPALPOD" ]; then
+    set -x
+fi
+
+DRUPAL_DIR="${GITPOD_REPO_ROOT}"/drupal-website
+mkdir -p "$DRUPAL_DIR"
+
+cd "$DRUPAL_DIR" && ddev config --create-docroot --docroot=web  --project-type=drupal9
+cd "$DRUPAL_DIR" && ddev composer create -y drupal/recommended-project
+cd "$DRUPAL_DIR" && ddev composer require drush/drush:^10
+# Add rector source code as symlink (to ../)
+cd "$DRUPAL_DIR" && composer config repositories.drupal-rector '{"type": "path", "url": "../", "options": {"symlink": true}}'
+# Get all drupal-rector dependencies
+cd "$DRUPAL_DIR" && ddev composer require palantirnet/drupal-rector:\"*\"
+
+# Create hard link of rector.php file
+cd "$DRUPAL_DIR" && ln ../rector.php .
+
+# Install standard drupal profile page
+cd "$DRUPAL_DIR" && ddev drush si -y --account-pass=admin --site-name="Drupal\ Rector" standard

--- a/.gitpod/phpstorm.template.sh
+++ b/.gitpod/phpstorm.template.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+if [ -n "$DEBUG_DRUPALPOD" ]; then
+    set -x
+fi
+
+if [ ! -x ~/.projector/configs/PhpStorm/run.sh ]; then
+  echo "PhpStorm runner not found" && exit 1
+fi
+~/.projector/configs/PhpStorm/run.sh "$GITPOD_REPO_ROOT"

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Our goal is to make contributing to this project easy for people. While we've ma
 
 ## Development environment
 
-We recommend using Gitpod, a full development environment in the cloud.
+You may use Gitpod, a full development environment in the cloud.
 <br>
 Click on this button to start -
 <br>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 # Drupal Rector
 
 Automate fixing deprecated Drupal code.
@@ -148,11 +150,25 @@ Thanks for your interest in contributing!
 
 Our goal is to make contributing to this project easy for people. While we've made certain architectural decisions here to hopefully achieve that goal, it's a work in progress and feedback is appreciated.
 
-### Development environment
+## Development environment
 
-We recommend using our `drupal-rector-sandbox` development environment [https://github.com/palantirnet/drupal-rector-sandbox](https://github.com/palantirnet/drupal-rector-sandbox)
+We recommend using Gitpod, a full development environment in the cloud.
+<br>
+Click on this button to start -
+<br>
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+<br>
+The Gitpod environment comes with a Drupal website installed under `drupal-website/` directory<br>
+Here's how you can run Drupal Rector in that environment:
+```
+cd drupal-website
+composer require drupal/pathauto
+vendor/bin/rector process web/modules/contrib/pathauto --dry-run
+```
 
-Alternatively, you can use your existing Drupal project and follow the instructions in [README](https://github.com/palantirnet/drupal-rector-sandbox/blob/master/README.md#developing-with-drupal-rector)
+Alternatively, you can use our `drupal-rector-sandbox` development environment locally [https://github.com/palantirnet/drupal-rector-sandbox](https://github.com/palantirnet/drupal-rector-sandbox)
+
+Or you can use your existing Drupal project and follow the instructions in [README](https://github.com/palantirnet/drupal-rector-sandbox/blob/master/README.md#developing-with-drupal-rector)
 
 ### Adding a Rector rule
 


### PR DESCRIPTION
## Description
The purpose of this PR is to fully automate the dev setup of Drupal Rector with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Gitpod provides automated dev environments in the cloud (free to use for public repos).
By adding `.gitpod.yml` file to this repo, we will improve developer experience when working on Drupal Rector repo, without modifying the current way developers working on it.

When clicking on "Open in Gitpod" button, a user gets a whole development environment in their browser.
Eliminating the need for each contributor to figure out how to setup a development environment. 

This is an additive change, so it wouldn't affect anyone who wants to continue work on their local machine, but will lower the barriers for anyone who wants to contribute.

In order to automatically generate Gitpod prebuilds, this Github app https://github.com/apps/gitpod-io should be authorized to run on this repo.

## To Test
* Click on [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
* If a login screen appears, authorize Gitpod with Github
* Wait for VSCode interface to load
* In the terminal panel type -
```
cd drupal-website
composer require drupal/pathauto
vendor/bin/rector process web/modules/contrib/pathauto --dry-run
```
- Confirm Drupal Rector works as expected.

## Drupal.org issue
https://www.drupal.org/node/3227040

<a href="https://gitpod.io/#https://github.com/shaal/drupal-rector/pull/4"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

